### PR TITLE
perf(callback): remove callback validation

### DIFF
--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -8,8 +8,8 @@
 
 local pendingCallbacks = {}
 local timers = {}
-local cbEvent = '__ox_cb_%s'
-local callbackTimeout = GetConvarInt('ox:callbackTimeout', 300000)
+local cbEvent = '__er_cb_%s'
+local callbackTimeout = GetConvarInt('er:callbackTimeout', 300000)
 
 RegisterNetEvent(cbEvent:format(cache.resource), function(key, ...)
   if source == '' then return end
@@ -52,7 +52,7 @@ local function triggerServerCallback(_, event, delay, cb, ...)
     key = ('%s:%s'):format(event, math.random(0, 100000))
   until not pendingCallbacks[key]
 
-  TriggerServerEvent('er_lib:validateCallback', event, cache.resource, key)
+  -- TriggerServerEvent('er_lib:validateCallback', event, cache.resource, key)
   TriggerServerEvent(cbEvent:format(event), cache.resource, key, ...)
 
   ---@type promise | false

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -7,8 +7,8 @@
 ]]
 
 local pendingCallbacks = {}
-local cbEvent = '__ox_cb_%s'
-local callbackTimeout = GetConvarInt('ox:callbackTimeout', 300000)
+local cbEvent = '__er_cb_%s'
+local callbackTimeout = GetConvarInt('er:callbackTimeout', 300000)
 
 RegisterNetEvent(cbEvent:format(cache.resource), function(key, ...)
   local cb = pendingCallbacks[key]
@@ -35,7 +35,7 @@ local function triggerClientCallback(_, event, playerId, cb, ...)
     key = ('%s:%s:%s'):format(event, math.random(0, 100000), playerId)
   until not pendingCallbacks[key]
 
-  TriggerClientEvent('er_lib:validateCallback', playerId, event, cache.resource, key)
+  -- TriggerClientEvent('er_lib:validateCallback', playerId, event, cache.resource, key)
   TriggerClientEvent(cbEvent:format(event), playerId, cache.resource, key, ...)
 
   ---@type promise | false

--- a/package/client/resource/callback/index.ts
+++ b/package/client/resource/callback/index.ts
@@ -1,9 +1,9 @@
 import { cache } from '../cache';
 
 const pendingCallbacks: Record<string, (...args: any[]) => void> = {};
-const callbackTimeout = GetConvarInt('ox:callbackTimeout', 300000);
+const callbackTimeout = GetConvarInt('er:callbackTimeout', 300000);
 
-onNet(`__ox_cb_${cache.resource}`, (key: string, ...args: any) => {
+onNet(`__er_cb_${cache.resource}`, (key: string, ...args: any) => {
   if (!source) return;
 
   const resolve = pendingCallbacks[key];
@@ -42,8 +42,8 @@ export function triggerServerCallback<T = unknown>(
     key = `${eventName}:${Math.floor(Math.random() * (100000 + 1))}`;
   } while (pendingCallbacks[key]);
 
-  emitNet(`er_lib:validateCallback`, eventName, cache.resource, key);
-  emitNet(`__ox_cb_${eventName}`, cache.resource, key, ...args);
+  // emitNet(`er_lib:validateCallback`, eventName, cache.resource, key);
+  emitNet(`__er_cb_${eventName}`, cache.resource, key, ...args);
 
   return new Promise<T>((resolve, reject) => {
     pendingCallbacks[key] = (args) => {
@@ -59,7 +59,7 @@ export function triggerServerCallback<T = unknown>(
 export function onServerCallback(eventName: string, cb: (...args: any[]) => any) {
   exports.er_lib.setValidCallback(eventName, true);
 
-  onNet(`__ox_cb_${eventName}`, async (resource: string, key: string, ...args: any[]) => {
+  onNet(`__er_cb_${eventName}`, async (resource: string, key: string, ...args: any[]) => {
     let response: any;
 
     try {
@@ -69,6 +69,6 @@ export function onServerCallback(eventName: string, cb: (...args: any[]) => any)
       console.log(`^3${e.stack}^0`);
     }
 
-    emitNet(`__ox_cb_${resource}`, key, response);
+    emitNet(`__er_cb_${resource}`, key, response);
   });
 }

--- a/package/server/resource/callback/index.ts
+++ b/package/server/resource/callback/index.ts
@@ -1,9 +1,9 @@
 import { cache } from '../cache';
 
 const pendingCallbacks: Record<string, (...args: any[]) => void> = {};
-const callbackTimeout = GetConvarInt('ox:callbackTimeout', 300000);
+const callbackTimeout = GetConvarInt('er:callbackTimeout', 300000);
 
-onNet(`__ox_cb_${cache.resource}`, (key: string, ...args: any) => {
+onNet(`__er_cb_${cache.resource}`, (key: string, ...args: any) => {
   const resolve = pendingCallbacks[key];
 
   if (!resolve) return;
@@ -24,8 +24,8 @@ export function triggerClientCallback<T = unknown>(
     key = `${eventName}:${Math.floor(Math.random() * (100000 + 1))}:${playerId}`;
   } while (pendingCallbacks[key]);
 
-  emitNet(`er_lib:validateCallback`, playerId, eventName, cache.resource, key);
-  emitNet(`__ox_cb_${eventName}`, playerId, cache.resource, key, ...args);
+  // emitNet(`er_lib:validateCallback`, playerId, eventName, cache.resource, key);
+  emitNet(`__er_cb_${eventName}`, playerId, cache.resource, key, ...args);
 
   return new Promise<T>((resolve, reject) => {
     pendingCallbacks[key] = (args) => {
@@ -41,7 +41,7 @@ export function triggerClientCallback<T = unknown>(
 export function onClientCallback(eventName: string, cb: (playerId: number, ...args: any[]) => any) {
   exports.er_lib.setValidCallback(eventName, true);
 
-  onNet(`__ox_cb_${eventName}`, async (resource: string, key: string, ...args: any[]) => {
+  onNet(`__er_cb_${eventName}`, async (resource: string, key: string, ...args: any[]) => {
     const src = source;
     let response: any;
 
@@ -52,6 +52,6 @@ export function onClientCallback(eventName: string, cb: (playerId: number, ...ar
       console.log(`^3${e.stack}^0`);
     }
 
-    emitNet(`__ox_cb_${resource}`, src, key, response);
+    emitNet(`__er_cb_${resource}`, src, key, response);
   });
 }

--- a/resource/callbacks/shared.lua
+++ b/resource/callbacks/shared.lua
@@ -56,7 +56,7 @@ function lib.isCallbackValid(callbackName)
   return registeredCallbacks[callbackName] == GetInvokingResource() or cache.resource
 end
 
-local cbEvent = '__ox_cb_%s'
+local cbEvent = '__er_cb_%s'
 
 RegisterNetEvent('er_lib:validateCallback', function(callbackName, invokingResource, key)
   if registeredCallbacks[callbackName] then return end


### PR DESCRIPTION
change to er prefix to avoid some server using ox_lib and remove validation because it add extra trigger that is not necessary